### PR TITLE
Opaque components

### DIFF
--- a/src/lasso_3d/_widget.py
+++ b/src/lasso_3d/_widget.py
@@ -250,7 +250,8 @@ class Lasso3D(QWidget):
         mask = mask_via_extension(points, volume_shape)
 
         # add the mask to the viewer
-        self.viewer.add_image(mask, name="mask")
+        mask_layer = self.viewer.add_image(mask, name="mask", opacity=0.4)
+        mask_layer.colormap = "green"
 
         return
 


### PR DESCRIPTION
This PR makes connected components that are not of interest opaque. To do so, the connected components layer is converted to a labels layer and the color map is changed.

Also the lasso-generated mask is now green and opaque.